### PR TITLE
Fix : handle zero values correctly (array of arrays)

### DIFF
--- a/src/modules/convert-array-of-arrays-to-csv.js
+++ b/src/modules/convert-array-of-arrays-to-csv.js
@@ -17,7 +17,7 @@ export const convertArrayOfArraysToCSV = (data, { header, separator }) => {
 
   array.forEach((row) => {
     row.forEach((value, i) => {
-      const thisValue = value || '';
+      const thisValue = value || ((value === 0)?0:'');
       const includesSpecials = checkSpecialCharsAndEmpty(thisValue);
       csv +=
         (includesSpecials ? `"${thisValue}"` : thisValue) +

--- a/src/modules/convert-array-of-arrays-to-csv.js
+++ b/src/modules/convert-array-of-arrays-to-csv.js
@@ -17,7 +17,7 @@ export const convertArrayOfArraysToCSV = (data, { header, separator }) => {
 
   array.forEach((row) => {
     row.forEach((value, i) => {
-      const thisValue = value || ((value === 0)?0:'');
+      const thisValue = value || (value === 0 ? 0 : '');
       const includesSpecials = checkSpecialCharsAndEmpty(thisValue);
       csv +=
         (includesSpecials ? `"${thisValue}"` : thisValue) +

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -14,6 +14,12 @@ const dataArrayWithNullAndUndefined = [
   [3, 'Larry', 'the Bird', '@twitter'],
 ];
 
+const dataArrayWithZero = [
+	[0, 'Mark', 'Otto', '@mdo'],
+	[1, 'Jacob', 'Thornton', '@fat'],
+	[2, 'Larry', 'the Bird', '@twitter'],
+]
+
 const data = [
   {
     number: 1,
@@ -76,4 +82,9 @@ export const dataObjectWithNullAndUndefined = [
 export const dataArrayWithHeaderAndNullAndUndefined = [
   ...headerArray,
   ...dataArrayWithNullAndUndefined,
+];
+
+export const dataArrayWithHeaderAndZero = [
+  ...headerArray,
+  ...dataArrayWithZero,
 ];

--- a/test/fixtures/expected-results.js
+++ b/test/fixtures/expected-results.js
@@ -8,6 +8,8 @@ export const expectedResultObjectNullAndUndefined = 'Number,First,Last,Handle\n1
 
 export const expectedResultArrayNullAndUndefined = 'number,first,last,handle\n1,Mark,"",@mdo\n2,Jacob,Thornton,""\n3,Larry,the Bird,@twitter\n';
 
+export const expectedResultArrayZero = 'number,first,last,handle\n0,Mark,Otto,@mdo\n1,Jacob,Thornton,@fat\n2,Larry,the Bird,@twitter\n';
+
 export const expectedResultObjectHeaderSeparatorSemicolon = 'Number;First;Last;Handle\n1;Mark;Otto;@mdo\n2;Jacob;Thornton;@fat\n3;Larry;the Bird;@twitter\n';
 
 export const expectedResultObjecOnlySeparatorTab = 'number\tfirst\tlast\thandle\n1\tMark\tOtto\t@mdo\n2\tJacob\tThornton\t@fat\n3\tLarry\tthe Bird\t@twitter\n';

--- a/test/modules/convert-array-of-arrays-to-csv.spec.js
+++ b/test/modules/convert-array-of-arrays-to-csv.spec.js
@@ -4,6 +4,7 @@ import {
   dataArrayWithHeader,
   dataArrayWithoutHeader,
   dataArrayWithHeaderAndNullAndUndefined,
+  dataArrayWithHeaderAndZero,
 } from '../fixtures/data';
 import {
   optionsHeaderSeperatorSemicolon,
@@ -19,6 +20,7 @@ import {
   expectedResultArrayHeaderSeparatorSemicolon,
   expectedResultArrayOnlySeparatorTab,
   expectedResultArrayNullAndUndefined,
+  expectedResultArrayZero,
 } from '../fixtures/expected-results';
 
 test('convertArrayOfArraysToCSV | array of arrays | with default options', () => {
@@ -61,4 +63,10 @@ test('convertArrayOfArraysToCSV | array of arrays with values of null and undefi
   const result = convertArrayOfArraysToCSV(dataArrayWithHeaderAndNullAndUndefined, optionsDefault);
 
   expect(result).toBe(expectedResultArrayNullAndUndefined);
+});
+
+test('convertArrayOfArraysToCSV | array of arrays with value of zero | with default options and no header', () => {
+  const result = convertArrayOfArraysToCSV(dataArrayWithHeaderAndZero, optionsDefault);
+
+  expect(result).toBe(expectedResultArrayZero);
 });

--- a/test/modules/convert-array-of-arrays-to-csv.spec.js
+++ b/test/modules/convert-array-of-arrays-to-csv.spec.js
@@ -65,7 +65,7 @@ test('convertArrayOfArraysToCSV | array of arrays with values of null and undefi
   expect(result).toBe(expectedResultArrayNullAndUndefined);
 });
 
-test('convertArrayOfArraysToCSV | array of arrays with value of zero | with default options and no header', () => {
+test('convertArrayOfArraysToCSV | array of arrays with value of zero | with default options and header', () => {
   const result = convertArrayOfArraysToCSV(dataArrayWithHeaderAndZero, optionsDefault);
 
   expect(result).toBe(expectedResultArrayZero);


### PR DESCRIPTION
When converting an array of array of numeric values ( world map storage ) to CSV, we encountered an issue, all zeros where replaced by "", which lead to map corruption.

The fix allow to preserve all 0 numeric values in the generated CSV string.