### PR TITLE
Fix: zero in header and body elements

### DIFF
--- a/src/modules/convert-array-of-arrays-to-csv.js
+++ b/src/modules/convert-array-of-arrays-to-csv.js
@@ -6,7 +6,7 @@ export const convertArrayOfArraysToCSV = (data, { header, separator }) => {
 
   if (header) {
     header.forEach((headerEl, i) => {
-      const thisHeaderEl = headerEl || '';
+      const thisHeaderEl = headerEl || (headerEl === 0 ? 0 : '');
 
       csv += appendElement(thisHeaderEl, header.length, i, separator);
     });

--- a/src/modules/convert-array-of-objects-to-csv.js
+++ b/src/modules/convert-array-of-objects-to-csv.js
@@ -6,7 +6,7 @@ export const convertArrayOfObjectsToCSV = (data, { header, separator }) => {
 
   if (header) {
     header.forEach((headerEl, i) => {
-      const thisHeaderEl = headerEl || '';
+      const thisHeaderEl = headerEl || (headerEl === 0 ? 0 : '');
 
       csv += appendElement(thisHeaderEl, header.length, i, separator);
     });
@@ -16,14 +16,14 @@ export const convertArrayOfObjectsToCSV = (data, { header, separator }) => {
     const thisRow = Object.keys(row);
     if (!header && idx === 0) {
       thisRow.forEach((key, i) => {
-        const value = key || '';
+        const value = key || (key === 0 ? 0 : '');
 
         csv += appendElement(value, thisRow.length, i, separator);
       });
     }
 
     thisRow.forEach((key, i) => {
-      const value = row[key] || '';
+      const value = row[key] || (row[key] === 0 ? 0 : '');
 
       csv += appendElement(value, thisRow.length, i, separator);
     });

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -116,6 +116,27 @@ const dataWithFloat = [
   },
 ];
 
+const dataWith0 = [
+  {
+    0: 0,
+    first: 'Mark',
+    last: 'Otto',
+    '': '@mdo',
+  },
+  {
+    0: 1,
+    first: 'Jacob',
+    last: 'Thornton',
+    '': '@fat',
+  },
+  {
+    0: 2,
+    first: 'Larry',
+    last: 'the Bird',
+    '': '@twitter',
+  },
+];
+
 export const dataArrayWithHeader = [
   ...headerArray,
   ...dataArray,
@@ -145,6 +166,10 @@ export const dataObjectWithFloat = [
   ...dataWithFloat,
 ];
 
+export const dataObjectWith0 = [
+  ...dataWith0,
+];
+
 export const dataArrayWithHeaderAndNullAndUndefined = [
   ...headerArray,
   ...dataArrayWithNullAndUndefined,
@@ -156,6 +181,5 @@ export const dataArrayWithHeaderAndFloats = [
 ];
 
 export const dataArrayWithHeaderAndZero = [
-  ...headerArray,
   ...dataArrayWithZero,
 ];

--- a/test/fixtures/expected-results.js
+++ b/test/fixtures/expected-results.js
@@ -12,7 +12,9 @@ export const expectedResultArrayWithFloats = 'number,first,last,handle\n1.001,Ma
 
 export const expectedResultObjectWithFloats = 'number,first,last,handle\n1.001,Mark,Otto,@mdo\n2.002,Jacob,Thornton,@fat\n3.33,Larry,"the Bird",@twitter\n';
 
-export const expectedResultArrayZero = 'number,first,last,handle\n0,Mark,Otto,@mdo\n1,Jacob,Thornton,@fat\n2,Larry,"the Bird",@twitter\n';
+export const expectedResultArrayZero = '0,first,last,""\n0,Mark,Otto,@mdo\n1,Jacob,Thornton,@fat\n2,Larry,"the Bird",@twitter\n';
+
+export const expectedResultObjectZero = '0,first,last,""\n0,Mark,Otto,@mdo\n1,Jacob,Thornton,@fat\n2,Larry,"the Bird",@twitter\n';
 
 export const expectedResultObjectHeaderSeparatorSemicolon = 'Number;First;Last;Handle\n1;Mark;Otto;@mdo\n2;Jacob;Thornton;@fat\n3;Larry;"the Bird";@twitter\n';
 

--- a/test/fixtures/options.js
+++ b/test/fixtures/options.js
@@ -22,3 +22,8 @@ export const optionsDefault = {
   header: undefined,
   separator: ',',
 };
+
+export const optionsHeaderZero = {
+  header: [0, 'first', 'last', ''],
+  separator: ',',
+};

--- a/test/modules/convert-array-of-arrays-to-csv.spec.js
+++ b/test/modules/convert-array-of-arrays-to-csv.spec.js
@@ -13,6 +13,7 @@ import {
   optionsHeaderSeparatorDefault,
   optionsHeaderDefaultSeperatorTab,
   optionsDefault,
+  optionsHeaderZero,
 } from '../fixtures/options';
 
 import {
@@ -76,7 +77,7 @@ test('convertArrayOfArraysToCSV | array of arrays with values of null and undefi
 });
 
 test('convertArrayOfArraysToCSV | array of arrays with value of zero | with default options and header', () => {
-  const result = convertArrayOfArraysToCSV(dataArrayWithHeaderAndZero, optionsDefault);
+  const result = convertArrayOfArraysToCSV(dataArrayWithHeaderAndZero, optionsHeaderZero);
 
   expect(result).toBe(expectedResultArrayZero);
 });

--- a/test/modules/convert-array-of-objects-to-csv.spec.js
+++ b/test/modules/convert-array-of-objects-to-csv.spec.js
@@ -5,12 +5,14 @@ import {
   dataObjectWithNullAndUndefined,
   dataObjectWithDoubleQuotesInsideElement,
   dataObjectWithFloat,
+  dataObjectWith0,
 } from '../fixtures/data';
 import {
   optionsHeaderSeperatorSemicolon,
   optionsHeaderSeparatorDefault,
   optionsHeaderDefaultSeperatorTab,
   optionsDefault,
+  optionsHeaderZero,
 } from '../fixtures/options';
 
 import {
@@ -21,6 +23,7 @@ import {
   expectedResultObjectNullAndUndefined,
   expectedResultObjectWithDoubleQoutesInsideElement,
   expectedResultObjectWithFloats,
+  expectedResultObjectZero,
 } from '../fixtures/expected-results';
 
 test('convertArrayOfObjectsToCSV | array of objects | with default options', () => {
@@ -66,4 +69,16 @@ test('convertArrayOfObjectsToCSV | array of objects with float | options: defaul
   const result = convertArrayOfObjectsToCSV(dataObjectWithFloat, optionsDefault);
 
   expect(result).toBe(expectedResultObjectWithFloats);
+});
+
+test('convertArrayOfObjectsToCSV | array of objects with value of zero | options: header with zero and "" + default separator', () => {
+  const result = convertArrayOfObjectsToCSV(dataObjectWith0, optionsHeaderZero);
+
+  expect(result).toBe(expectedResultObjectZero);
+});
+
+test('convertArrayOfObjectsToCSV | array of objects with value of zero | options: default header + default separator', () => {
+  const result = convertArrayOfObjectsToCSV(dataObjectWith0, optionsDefault);
+
+  expect(result).toBe(expectedResultObjectZero);
 });


### PR DESCRIPTION
This PR resolves #18 

if a zero (0) was in a body element e.g. 

```js
[
  {
    0: 'the header element is a zero',
    theBodyElementIsAZero: 0,
  },
]
```

the output was 

```sh
"", theBodyElementIsAZero
"the header element is a zero", ""
```

now this is fixed e.g.

```sh
0, theBodyElementIsAZero
"the header element is a zero", 0
```