### PR TITLE
Support null or false to omit header row

### DIFF
--- a/src/modules/convert-array-of-objects-to-csv.js
+++ b/src/modules/convert-array-of-objects-to-csv.js
@@ -15,7 +15,7 @@ export const convertArrayOfObjectsToCSV = (data, { header, separator }) => {
 
   array.forEach((row, idx) => {
     const thisRow = Object.keys(row);
-    if (!header && idx === 0) {
+    if (header === undefined && idx === 0) {
       thisRow.forEach((key, i) => {
         const value = valueOrEmpty(key);
 

--- a/test/fixtures/expected-results.js
+++ b/test/fixtures/expected-results.js
@@ -2,6 +2,8 @@ export const expectedResultArrayNoHeaderNoOptions = '1,Mark,Otto,@mdo\n2,Jacob,T
 
 export const expectedResultObjectNoOptions = 'number,first,last,handle\n1,Mark,Otto,@mdo\n2,Jacob,Thornton,@fat\n3,Larry,the Bird,@twitter\n';
 
+export const expectedResultObjectNoHeader = '1,Mark,Otto,@mdo\n2,Jacob,Thornton,@fat\n3,Larry,the Bird,@twitter\n';
+
 export const expectedResultObjectOnlyHeader = 'Number,First,Last,Handle\n1,Mark,Otto,@mdo\n2,Jacob,Thornton,@fat\n3,Larry,the Bird,@twitter\n';
 
 export const expectedResultObjectNullAndUndefined = 'Number,First,Last,Handle\n1,Mark,"",@mdo\n2,Jacob,Thornton,""\n3,Larry,the Bird,@twitter\n';

--- a/test/fixtures/options.js
+++ b/test/fixtures/options.js
@@ -3,6 +3,11 @@ export const optionsHeaderSeparatorDefault = {
   separator: ',',
 };
 
+export const optionsNullHeaderSeparatorDefault = {
+  header: null,
+  separator: ',',
+};
+
 export const optionsHeaderWithSpacesSeparatorDefault = {
   header: ['number number', 'first', 'last', 'handle'],
   separator: ',',

--- a/test/modules/convert-array-of-objects-to-csv.spec.js
+++ b/test/modules/convert-array-of-objects-to-csv.spec.js
@@ -10,6 +10,7 @@ import {
 import {
   optionsHeaderSeparatorSemicolon,
   optionsHeaderSeparatorDefault,
+  optionsNullHeaderSeparatorDefault,
   optionsHeaderDefaultSeparatorTab,
   optionsDefault,
   optionsHeaderZero,
@@ -19,6 +20,7 @@ import {
   expectedResultObjectNoOptions,
   expectedResultObjectHeaderSeparatorSemicolon,
   expectedResultObjectOnlyHeader,
+  expectedResultObjectNoHeader,
   expectedResultObjectOnlySeparatorTab,
   expectedResultObjectNullAndUndefined,
   expectedResultObjectWithDoubleQuotesInsideElement,
@@ -48,6 +50,12 @@ test('convertArrayOfObjectsToCSV | array of objects | options: header + default 
   const result = convertArrayOfObjectsToCSV(dataObject, optionsHeaderSeparatorDefault);
 
   expect(result).toBe(expectedResultObjectOnlyHeader);
+});
+
+test('convertArrayOfObjectsToCSV | array of objects | options: header = null + default separator', () => {
+  const result = convertArrayOfObjectsToCSV(dataObject, optionsNullHeaderSeparatorDefault);
+
+  expect(result).toBe(expectedResultObjectNoHeader);
 });
 
 test('convertArrayOfObjectsToCSV | array of objects | options: default header + separator tab', () => {


### PR DESCRIPTION
In my case, I had an array of objects but did not want the header row. 

This change allows for `options.header` to be set to `null` or `false` to explicitly omit the header row.